### PR TITLE
Add an opt-in border for all tabs in the vertical sidebar based on 'natsumi.sidebar.border-all' configuration key

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ and delay, change the variables in the config.css file.
 - `natsumi.sidebar.unlimited-pinned-tabs`: Removes the limit on the maximum number of tabs being shown
   in the pinned section of the vertical tabs.
 - `natsumi.sidebar.zen-sidebar-glass-effect`: Adds glass effect to Zen Sidebar.
+- `natsumi.sidebar.border-all`: Adds a border to all tabs irrespective of whether its the active tab or not.
 
 ### Findbar
 - `natsumi.findbar.disabled`: Disables Natsumi Findbar and reverts the findbar style back.

--- a/natsumi/modules/natsumi-base.css
+++ b/natsumi/modules/natsumi-base.css
@@ -114,7 +114,9 @@ their author(s) have been provided above the used code.
 
   &[usercontextid] {
     .tab-background {
-      border: 1px solid var(--identity-tab-color) !important;
+      @media (-moz-bool-pref: "natsumi.sidebar.border-all") {
+        border: 1px solid var(--identity-tab-color) !important;
+      }
 
       &::before {
         opacity: 1;


### PR DESCRIPTION
This preserves the same tab border style from the pre-2.0.0 UI. Only the active tab will have the full border, while all the other tabs will not show the border all around.

Older UI (ie with the opt-in boolean config either missing or `false`):
<img width="103" alt="Screenshot 2024-12-30 at 19 51 02" src="https://github.com/user-attachments/assets/d9535a07-6151-4dc6-a998-557ba41be17a" />

Newer UI (with the opt-in boolean config set to `true`)
<img width="86" alt="Screenshot 2024-12-30 at 19 52 54" src="https://github.com/user-attachments/assets/01fdc17f-115c-486b-9455-d9a0dd32333b" />


imho: the "border around all tabs" is quite jarring since it makes the UI very cluttered. Please do accept this PR.