### PR TITLE
Minor changes adjusting drop shadow and workspace saturation

### DIFF
--- a/natsumi/modules/natsumi-base.css
+++ b/natsumi/modules/natsumi-base.css
@@ -50,7 +50,7 @@ their author(s) have been provided above the used code.
       background-color: light-dark(rgba(255,255,255,1), rgba(255,255,255,0.2)) !important;
       box-shadow: 0 0 4px rgba(0,0,0,0.2) !important;
       overflow: hidden !important;
-      filter: saturate(120%) brightness(110%) !important;
+      filter: none !important;
 
       &::before {
         content: "";

--- a/natsumi/modules/natsumi-base.css
+++ b/natsumi/modules/natsumi-base.css
@@ -31,6 +31,7 @@ their author(s) have been provided above the used code.
 
 /* Workspaces button */
 
+
 #zen-workspaces-button {
   border-radius: 8px !important;
   background-color: rgba(255,255,255,0.1) !important;
@@ -40,12 +41,16 @@ their author(s) have been provided above the used code.
   .subviewbutton {
     border-radius: 6px !important;
     transition: background-color 0.2s ease !important;
+    font-size: 16px !important;
+    filter: grayscale(0%) !important;
+
 
     /*noinspection CssInvalidFunction*/
     &[active] {
       background-color: light-dark(rgba(255,255,255,1), rgba(255,255,255,0.2)) !important;
       box-shadow: 0 0 4px rgba(0,0,0,0.2) !important;
       overflow: hidden !important;
+      filter: saturate(120%) brightness(110%) !important;
 
       &::before {
         content: "";

--- a/natsumi/modules/natsumi-base.css
+++ b/natsumi/modules/natsumi-base.css
@@ -205,7 +205,7 @@ their author(s) have been provided above the used code.
     }
 
     .tab-background {
-      box-shadow: 0 3px 4px 0 rgba(0, 0, 0, 0.3) !important;
+      box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3) !important;
     }
 
     &:not([usercontextid]) .tab-background {

--- a/natsumi/modules/natsumi-base.css
+++ b/natsumi/modules/natsumi-base.css
@@ -50,7 +50,6 @@ their author(s) have been provided above the used code.
       background-color: light-dark(rgba(255,255,255,1), rgba(255,255,255,0.2)) !important;
       box-shadow: 0 0 4px rgba(0,0,0,0.2) !important;
       overflow: hidden !important;
-      filter: none !important;
 
       &::before {
         content: "";


### PR DESCRIPTION
idk these just seemed nice

Before:
<img width="273" alt="Screenshot 2025-01-01 at 12 18 11 AM" src="https://github.com/user-attachments/assets/f8a362f4-0c06-406f-a7fc-6276b92fc941" />

after:
<img width="278" alt="Screenshot 2025-01-01 at 12 18 29 AM" src="https://github.com/user-attachments/assets/6414f201-2e26-423c-b13f-a74df3c9e51e" />

added color to the workpace icons:


<img width="289" alt="Screenshot 2025-01-01 at 12 19 38 AM" src="https://github.com/user-attachments/assets/58e1123d-a070-43e5-9f16-0314fa17d22a" />
