### PR TITLE
Fix navbar width during customization mode

### DIFF
--- a/natsumi/modules/navbar.css
+++ b/natsumi/modules/navbar.css
@@ -54,6 +54,10 @@ their author(s) have been provided above the used code.
         border: 1px solid light-dark(rgba(20, 20, 20, 0.2), rgba(235, 235, 235, 0.3)) !important;
         backdrop-filter: blur(var(--natsumi-glass-blur-radius)) !important;
 
+        :root[customizing] & {
+          width: auto !important;
+        }
+
         &:not([zen-has-hover]):not([zen-user-show]):not([has-popup-menu]):not(:has(*[open='true'])):not(:focus-within) {
           backdrop-filter: none !important;
         }


### PR DESCRIPTION
When customizing the browser, the natsumi mod causes the navbar to grow wider than the visible area. This is because, the mod sets the width to `100vw - 2px` not taking into account that the sidebar is visible when customizing.

![CleanShot 2025-02-26 at 19 31 09@2x](https://github.com/user-attachments/assets/3709bcd6-f262-43ad-bb65-8a84e1743627)
