### PR TITLE
Add system accent color 

### DIFF
--- a/natsumi/global/colors.css
+++ b/natsumi/global/colors.css
@@ -88,3 +88,9 @@ their author(s) have been provided above the used code.
     --natsumi-custom-primary-color: #d4bbff;
   }
 }
+
+@media -moz-pref("natsumi.theme.accent-color", "system") {
+  * {
+    --natsumi-custom-primary-color: AccentColor;
+  }
+}


### PR DESCRIPTION
Uses the AccentColor variable provided by the system, on Windows this will be blue no matter the accent colour unfortunately, but on Linux it will follow [the system's accent colour](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html#description) 
(Not sure about macOS)