### PR TITLE
Natsumi 5.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-latest, ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -122,8 +122,7 @@ jobs:
           artifactErrorsFailBuild: true
           artifacts: 'natsumi-installer-macos-arm64/natsumi-installer-macos-arm64,
             natsumi-installer-macos-x64/natsumi-installer-macos-intel,
-            natsumi-installer-linux/natsumi-installer-linux,
-            natsumi-installer-windows/natsumi-installer.exe'
+            natsumi-installer-linux/natsumi-installer-linux'
 
 
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cost of losing some features.
 You will need to install Natsumi by copying its files to your profile's chrome folder.
 
 ### Automatic install
-#### Installing via installer
+#### Installing via installer (macOS/Linux only)
 Every release of Natsumi from v5 comes with an installer binary. You can run it to install Natsumi
 Browser, Natsumi Browser Pages and Natsumi Append to your browser and profile of choice.
 

--- a/installer/installer.json
+++ b/installer/installer.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Natsumi Browser",
     "author": "Green (@greeeen-dev)",
-    "version": "5.2.1",
+    "version": "5.2.2",
     "version_rc": null,
     "version_beta": null,
     "version_alpha": null,

--- a/theme.json
+++ b/theme.json
@@ -4,7 +4,7 @@
   "author": "greeeen-dev",
   "name": "Natsumi Browser",
   "description": "A skin for Firefox and its forks that makes things flow.",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "createdAt": "2024-12-06T10:19:47Z",
   "readme": "https://raw.githubusercontent.com/greeeen-dev/natsumi-browser/main/README.md",
   "image": "https://github.com/greeeen-dev/natsumi-browser/raw/dev/images/main-backgroundless.png",


### PR DESCRIPTION
Basically removes Windows installer because Windows is ass and cannot stop flagging the installer as a trojan