### PR TITLE
feat: add support for Glide Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ All browsers must be based on Firefox 137 or above.
 | Firefox     | :white_check_mark: Supported  | 137+     |                                                                    |
 | Waterfox    | :white_check_mark: Supported  | 6.6.0+   |                                                                    |
 | Librewolf   | :white_check_mark: Supported  | 137+     | May have performance issues, but other than that fully compatible. |
+| Glide       | :white_check_mark: Supported  | 0.1.54a+ | Not tested very thoroughly yet.                                    |
 | Firedragon  | :warning: Partially supported | 12+      | Theoretically supported, but not yet tested.                       |
 | Midori      | :x: Unsupported               | -        | Incompatible (based on ESR128)                                     |
 | Mullvad/Tor | :x: Unsupported               | 15.0+    | Incompatible (based on ESR128, version 15 is in alpha)             |

--- a/installer/installer.py
+++ b/installer/installer.py
@@ -139,7 +139,8 @@ browsers = [
     BrowserEntry('Firefox', 'mozilla', 'Firefox', 'org.mozilla.firefox', 'Mozilla/Firefox', 'Mozilla Firefox'),
     BrowserEntry('Floorp', 'floorp', 'Floorp', None, 'Floorp', 'Floorp'),
     BrowserEntry('Waterfox', 'waterfox', 'Waterfox', None, 'Waterfox/Waterfox', 'Waterfox'),
-    BrowserEntry('Librewolf', 'librewolf', 'LibreWolf', 'io.gitlab.librewolf-community', 'librewolf', 'librewolf')
+    BrowserEntry('Librewolf', 'librewolf', 'LibreWolf', 'io.gitlab.librewolf-community', 'librewolf', 'librewolf'),
+    BrowserEntry('Glide', 'glide-browser', 'Glide', None, None, None)
 ]
 
 def get_profiles(path):


### PR DESCRIPTION
This PR adds support for [Glide](https://glide-browser.app/) to the installer, and documents Glide support in the README.

I tested the installer with:
```
$ uv venv .venv
$ source .venv/bin/activate
$ uv pip install -r requirements.txt
$ python installer.py
```
I went through the setup flow, and confirmed the Natsumi url bar works:

<img width="1259" height="755" alt="Screenshot 2025-11-30 at 2 05 03 am" src="https://github.com/user-attachments/assets/57f6d1ba-6ce0-4f87-9ed5-14827a2bc38a" />

and settings works:

<img width="1390" height="545" alt="Screenshot 2025-11-30 at 2 14 30 am" src="https://github.com/user-attachments/assets/35f3746e-5953-43ea-997b-efe033d07464" />

<img width="1390" height="545" alt="Screenshot 2025-11-30 at 2 14 47 am" src="https://github.com/user-attachments/assets/16c01306-98c3-4110-8f18-8c060e5d0b8a" />

but I didn't go much deeper than that; I also only tested this on macOS.

---

Notes:
1. I am the creator of Glide
2. Glide doesn't have official support for Windows yet
3. Glide doesn't have a flathub package (I am trying)
4. The `BrowserEntry()` code would be much easier to understand / maintain if it used keyword arguments imo, would be happy to make that change in a separate commit if that change is desirable :)