### PR TITLE
chore: Simplify CSS links into relative paths

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -9,8 +9,8 @@
   "readme": "https://raw.githubusercontent.com/greeeen-dev/natsumi-browser/main/README.md",
   "image": "https://github.com/greeeen-dev/natsumi-browser/raw/dev/images/main-backgroundless.png",
   "style": {
-    "chrome": "https://raw.githubusercontent.com/greeeen-dev/natsumi-browser/main/userChrome.css",
-    "content": "https://raw.githubusercontent.com/greeeen-dev/natsumi-browser/main/userContent.css"
+    "chrome": "userChrome.css",
+    "content": "userContent.css"
   },
   "chromeManifest": "sine-chrome.manifest",
   "tags": [


### PR DESCRIPTION
Sine v2.3 has finally released on Cosine (labeled as v2.3c), meaning that Sine users can now install Natsumi in their favorite theme manager!

Regardless, Sine v2.3 has a new mod installation method that allows for CSS files to be linked as relative paths instead of URLs, slightly cleaning up the theme.json, so I figured I'd implement it here.