### PR TITLE
Use native -moz-pref syntax

### DIFF
--- a/natsumi/modules/preload.css
+++ b/natsumi/modules/preload.css
@@ -51,7 +51,7 @@ SOFTWARE.
     --natsumi-colors-urlbar-background: transparent;
     --natsumi-ff-background-color: color-mix(in srgb, var(--natsumi-primary-color) 15%, black);
 
-    @media (-moz-bool-pref: 'natsumi.theme.colors-colorful') {
+    @media -moz-pref("natsumi.theme.colors-colorful") {
       --natsumi-colors-primary: color-mix(in srgb, var(--natsumi-primary-color) 50%, black 50%);
       --natsumi-colors-secondary: color-mix(in srgb, var(--natsumi-primary-color) 40%, black 60%);
       --natsumi-colors-tertiary: color-mix(in srgb, var(--natsumi-primary-color) 15%, black 85%);


### PR DESCRIPTION
## Checklist
<!--
Please make sure all of the following applies to your issue.

Quick links:
- Code of Conduct: https://github.com/greeeen-dev/natsumi-browser/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/greeeen-dev/natsumi-browser/blob/main/.github/CONTRIBUTING.md
-->
- [x] My code follows the repository's Code of Conduct.
- [x] My submission is in line with the Contributing Guidelines.
- [x] I have tested this code to make sure it works as intended (this may be left unchecked if the PR is opened as a draft).
- [x] I have declared any use of artificial intelligence (AI) tools.

## Details
<!--
What did you change? What did you add? What did you fix? Tell us here!
-->
The current code in `natsumi/modules/preload.css` uses `-moz-bool-pref`, something only available in Zen. I have switched it to use Firefox's native `-moz-pref` syntax.

## Screenshots

## Per-file description
<!--
Describe the changes you've made on a per-file basis. Include descriptions of your code, how it works and what it does.

This field is optional for maintainers.
-->
Only one file changed, all the changes listed above.

## AI use declaration
<!--
Tick one field that best matches your use of AI tools.
-->
- [ ] AI tools were used to create the majority of this contribution.
- [ ] AI tools were partially used to assist with this contribution.
- [x] No AI tools whatsoever were used to create this contribution.

### AI use details
<!--
Describe your use of AI tools here. If no AI tools were used, leave this empty.
-->
