### PR TITLE
Fix rounded corners on Windows PiP

### DIFF
--- a/natsumi/modules/pip.css
+++ b/natsumi/modules/pip.css
@@ -70,6 +70,7 @@ SOFTWARE.
         window, html, body {
           /* Share same radius as macOS for the sake of simplicity later */
           border-radius: 9px !important;
+          background: transparent !important;
         }
       }
     }


### PR DESCRIPTION
## Checklist
<!--
Please make sure all of the following applies to your issue.

Quick links:
- Code of Conduct: https://github.com/greeeen-dev/natsumi-browser/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/greeeen-dev/natsumi-browser/blob/main/.github/CONTRIBUTING.md
-->
- [x] My code follows the repository's Code of Conduct.
- [x] My submission is in line with the Contributing Guidelines.
- [x] I have tested this code to make sure it works as intended (this may be left unchecked if the PR is opened as a draft).
- [x] I have declared any use of artificial intelligence (AI) tools.

## Details
The Windows PiP was not rounded, but by making the background transparent, it will round on Windows.

## Per-file description
Only one file changed, listed above.

## AI use declaration
- [ ] AI tools were used to create the majority of this contribution.
- [ ] AI tools were partially used to assist with this contribution.
- [x] No AI tools whatsoever were used to create this contribution.
