### PR TITLE
Fix miscolored bar next to open panel sidebar

### DIFF
--- a/natsumi/modules/floorp/panel-sidebar.css
+++ b/natsumi/modules/floorp/panel-sidebar.css
@@ -79,6 +79,7 @@ SOFTWARE.
     margin-inline: calc(calc(var(--natsumi-browser-separation) - 4px) / 2) !important;
     min-width: 4px !important;
     transition: background-color 0.5s ease-in-out;
+    background: transparent !important;
   }
 
   #panel-sidebar-box {


### PR DESCRIPTION
See discord forum post for an image.

## Checklist
<!--
Please make sure all of the following applies to your issue.

Quick links:
- Code of Conduct: https://github.com/greeeen-dev/natsumi-browser/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/greeeen-dev/natsumi-browser/blob/main/.github/CONTRIBUTING.md
-->
- [x] My code follows the repository's Code of Conduct.
- [x] My submission is in line with the Contributing Guidelines.
- [x] I have tested this code to make sure it works as intended (this may be left unchecked if the PR is opened as a draft).
- [x] I have declared any use of artificial intelligence (AI) tools.

## Details
<!--
What did you change? What did you add? What did you fix? Tell us here!
-->
There is a white bar next to the web panel in floorp for me. This fixes it.
## Screenshots
<img width="63" height="1451" alt="Screenshot_2026-06-13-20-52-48" src="https://github.com/user-attachments/assets/5df9bdaf-153c-4fd1-ae86-8bb0811fc7e6" />

## Per-file description
<!--
Describe the changes you've made on a per-file basis. Include descriptions of your code, how it works and what it does.

This field is optional for maintainers.
-->

## AI use declaration
<!--
Tick one field that best matches your use of AI tools.
-->
- [ ] AI tools were used to create the majority of this contribution.
- [ ] AI tools were partially used to assist with this contribution.
- [x] No AI tools whatsoever were used to create this contribution.

### AI use details
<!--
Describe your use of AI tools here. If no AI tools were used, leave this empty.
-->
