### PR TITLE
Add support for Pseudo background.

### DIFF
--- a/natsumi/modules/backdrop-blur.css
+++ b/natsumi/modules/backdrop-blur.css
@@ -56,3 +56,39 @@ SOFTWARE.
     }
   }
 }
+
+/*Pseudo-Background code*/
+/*ONLY WORKS ON ZEN, ESSENTIAL CHANGES MIGHT BE NEEDED TO BE MADE VIA CSS/JS*/
+/*Change class names. Also variable names can be changed as per your preferences*/
+
+#zen-toolbar-background {
+  backdrop-filter: none !important;
+  &::after,
+  &::before {
+    background-color: light-dark(
+      rgb(255 255 255 / 0%),
+      rgb(0 0 0 / 0%)
+    ) !important;
+  }
+}
+
+@media (-moz-pref("zen.view.compact.hide-tabbar")) {
+  :root[zen-compact-mode="true"] {
+    #navigator-toolbox:not([animate]) {
+      #zen-toolbar-background {
+        background-color: var(
+          --arc-compact-sidebar-bg,
+          light-dark(rgb(255 255 255 / 25%), rgb(0 0 0 / 25%))
+        ) !important;
+      }
+
+      #zen-toolbar-background {
+        border-radius: var(--arc-border-radius, 12px) !important;
+        backdrop-filter: blur(var(--arc-compact-sidebar-blur, 25px))
+          contrast(var(--arc-compact-sidebar-contrast, 1))
+          saturate(var(--arc-compact-sidebar-saturate, 1)) !important;
+        outline: none !important;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added code that works on Zen to apply pseudo background on compact elements so that they can still blur when hovered on an already translucent page. Essential formatting needed via CSS/JS to make it work on other browsers.
## Checklist
<!--
Please make sure all of the following applies to your issue.

Quick links:
- Code of Conduct: https://github.com/greeeen-dev/natsumi-browser/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/greeeen-dev/natsumi-browser/blob/main/.github/CONTRIBUTING.md
-->
- [ ] My code follows the repository's Code of Conduct.
- [ ] My submission is in line with the Contributing Guidelines.
- [ ] I have tested this code to make sure it works as intended (this may be left unchecked if the PR is opened as a draft).
- [ ] I have declared any use of artificial intelligence (AI) tools.

## Details
<!--
What did you change? What did you add? What did you fix? Tell us here!
--> Added Pseudo Background application code from Zen, which might need formatting for application on other browsers.

## Screenshots
<!--
Attach any screenshots showcasing your changes here. This is optional.
-->

## Per-file description
<!--
Describe the changes you've made on a per-file basis. Include descriptions of your code, how it works and what it does.

This field is optional for maintainers.
-->

## AI use declaration
<!--
Tick one field that best matches your use of AI tools.
-->
- [ ] AI tools were used to create the majority of this contribution.
- [ ] AI tools were partially used to assist with this contribution.
- [✅] No AI tools whatsoever were used to create this contribution.

### AI use details
<!--
Describe your use of AI tools here. If no AI tools were used, leave this empty.
-->
