### PR TITLE
Fix linux config paths

### DIFF
--- a/installer/installer.py
+++ b/installer/installer.py
@@ -115,17 +115,24 @@ def _get_windows_path(browser: BrowserEntry):
     return path
 
 def _get_linux_path(browser: BrowserEntry):
-    browser_path = home + f'/.{browser.name_universal}'
-    path = home + browser_path + '/Profiles'
+    xdg_config_home = os.environ.get(
+        'XDG_CONFIG_HOME',
+        home + '/.config'
+    )
+    
+    fallback_paths = [
+        home + f'/.{browser.name_universal}',
+        xdg_config_home + f'/{browser.name_universal}',
+    ]
 
-    if os.path.exists(browser_path):
-        if os.path.exists(path):
-            return path
+    for browser_path in fallback_paths:
+        profiles_path = browser_path + '/Profiles'
 
-        else:
-            if os.path.exists(browser_path):
-                return browser_path
-
+        if os.path.exists(profiles_path):
+            return profiles_path
+        
+        if os.path.exists(browser_path):
+            return browser_path
     raise NotADirectoryError('Browser is not installed')
 
 def _get_flatpak_path(browser: BrowserEntry):


### PR DESCRIPTION
## Checklist
<!--
Please make sure all of the following applies to your issue.

Quick links:
- Code of Conduct: https://github.com/greeeen-dev/natsumi-browser/blob/main/CODE_OF_CONDUCT.md
- Contributing Guidelines: https://github.com/greeeen-dev/natsumi-browser/blob/main/.github/CONTRIBUTING.md
-->
- [x] My code follows the repository's Code of Conduct.
- [x] My submission is in line with the Contributing Guidelines.
- [x] I have tested this code to make sure it works as intended (this may be left unchecked if the PR is opened as a draft).
- [x] I have declared any use of artificial intelligence (AI) tools.

## Details
<!--
What did you change? What did you add? What did you fix? Tell us here!
-->
Fixes issue #348 regarding profile directory paths. 
## Screenshots
<!--
Attach any screenshots showcasing your changes here. This is optional.
-->
Old behavior
<img width="487" height="344" alt="image" src="https://github.com/user-attachments/assets/7debe153-ad77-44f4-bf5b-2ddb9e3653be" />

New behavior
<img width="580" height="362" alt="image" src="https://github.com/user-attachments/assets/b2a31261-e660-4d9b-a546-00c9fde16ce5" />

## Per-file description
<!--
Describe the changes you've made on a per-file basis. Include descriptions of your code, how it works and what it does.

This field is optional for maintainers.
-->
`installer/installer.py`

* Added support for `$XDG_CONFIG_HOME` if `$XDG_CONFIG_HOME` does not exist it falls back to `~/.config`
* Added a list that contains the paths so if any future browsers to be supported do not follow XDG style paths we can just add it later.

## AI use declaration
<!--
Tick one field that best matches your use of AI tools.
-->
- [ ] AI tools were used to create the majority of this contribution.
- [ ] AI tools were partially used to assist with this contribution.
- [x] No AI tools whatsoever were used to create this contribution.

### AI use details
<!--
Describe your use of AI tools here. If no AI tools were used, leave this empty.
-->
